### PR TITLE
feat: Tweak VtsExec command to narrow down complete list

### DIFF
--- a/lua/vtsls/init.lua
+++ b/lua/vtsls/init.lua
@@ -28,8 +28,14 @@ return setmetatable({
 		end, {
 			desc = "Execute vtsls commands",
 			nargs = 1,
-			complete = function()
-				return vim.tbl_keys(require("vtsls.commands"))
+			complete = function(arglead)
+				local opts = vim.tbl_keys(require("vtsls.commands"))
+				if not arglead or arglead == "" then
+					return opts
+				end
+				return vim.tbl_filter(function(opt)
+					return vim.startswith(opt, arglead)
+				end, opts)
 			end,
 		})
 		if not vim.api.nvim_get_commands({})["VtsRename"] then


### PR DESCRIPTION
Hi,

Here's just a small tweak to the complete function for `VtsExec` command that will narrow down options once you start typing.

Thanks for the plugin and `vtsls`, seems to work a bit better than `typescript-language-server`.