### PR TITLE
Setup default configuration for nvim 0.11+

### DIFF
--- a/lsp/vtsls.lua
+++ b/lsp/vtsls.lua
@@ -1,0 +1,31 @@
+local cmd = { "vtsls", "--stdio" }
+
+if vim.fn.has("win32") == 1 then
+  cmd = { "cmd.exe", "/C", unpack(cmd) }
+end
+
+return {
+  cmd = cmd,
+  filetypes = {
+    "javascript",
+    "javascriptreact",
+    "javascript.jsx",
+    "typescript",
+    "typescriptreact",
+    "typescript.tsx",
+  },
+
+  root_markers = { "tsconfig.json", "jsonconfig.json", "package.json", ".git" },
+
+  settings = {
+    typescript = {
+      updateImportsOnFileMove = "always",
+    },
+    javascript = {
+      updateImportsOnFileMove = "always",
+    },
+    vtsls = {
+      enableMoveToFileCodeAction = true,
+    },
+  },
+}


### PR DESCRIPTION
Hello!

With nvim 0.11, you can define a default configuration for a LSP server by creating a `lsp/SERVER.lua` file anywhere in the runtimepath. I've made this PR so that setting up vtsls doesn't require calling `require("lspconfig.configs").vtsls = require("vtsls").lspconfig` anymore.

I've copied the content of the [`gen_config`](https://github.com/yioneko/nvim-vtsls/blob/45c6dfea9f83a126e9bfc5dd63430562b3f8af16/lua/vtsls/lspconfig.lua#L1) function but replacing calls to `lspconfig` and simplifying the root detection by using `vim.fs.root`.

Furthermore, this should not have any impact on config running on nvim < 0.10, since the `lsp/SERVER.lua` should only be loaded starting nvim 0.11. In the future, we might want to replace this by directly setting the configuration with `vim.lsp.config`.

Please let me know if you would like some additional changes or if you have some questions!