### PR TITLE
feat: use non-deprecated LSP methods if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ api.events.subscribe(api.events.Event.NodeRenamed, function(data)
           match_file_operation_filter(filter, data.old_name, type)
           and match_file_operation_filter(filter, data.new_name, type)
         then
-          client.notify(
+          client:notify(
             "workspace/didRenameFiles",
             { files = { { oldUri = uri_from_path(data.old_name), newUri = uri_from_path(data.new_name) } } }
           )

--- a/lua/vtsls/async.lua
+++ b/lua/vtsls/async.lua
@@ -52,7 +52,7 @@ end
 
 function M.request(client, method, params, bufnr)
 	return co.yield(function(cb)
-		client.request(method, params, cb, bufnr)
+		client:request(method, params, cb, bufnr)
 	end)
 end
 

--- a/lua/vtsls/compat.lua
+++ b/lua/vtsls/compat.lua
@@ -1,6 +1,24 @@
 local M = {}
 
-M.lsp_get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+M.lsp_get_clients = function(...)
+	local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)(...)
+	return vim.tbl_map(function(client)
+		if vim.fn.has("nvim-0.11") == 1 then
+			return client
+		end
+		return setmetatable({
+			is_stopped = function(_, ...)
+				return client.is_stopped(...)
+			end,
+			notify = function(_, ...)
+				return client.notify(...)
+			end,
+			request = function(_, ...)
+				return client.request(...)
+			end,
+		}, { __index = client })
+	end, clients)
+end
 
 local global_registered_commands = {}
 

--- a/lua/vtsls/rename.lua
+++ b/lua/vtsls/rename.lua
@@ -81,11 +81,11 @@ local function do_rename(client, old_path, new_path)
 		end
 	end
 
-	if client.is_stopped() then
+	if client:is_stopped() then
 		error("client not active")
 	end
 
-	client.notify("workspace/didRenameFiles", {
+	client:notify("workspace/didRenameFiles", {
 		files = {
 			{
 				oldUri = uri_from_path(old_path),


### PR DESCRIPTION
Gets rid of the deprecation warnings on nightly Neovim (see https://github.com/neovim/neovim/pull/31207).